### PR TITLE
Improve selection of file extensions for auto-mode-alist

### DIFF
--- a/xquery-mode.el
+++ b/xquery-mode.el
@@ -33,8 +33,6 @@
 ;;; Code:
 
 ;; TODO: 'if()' is highlighted as a function
-;; TODO: requiring nxml-mode excludes XEmacs - just for colors?
-;; TODO: test using featurep 'xemacs
 ;; TODO use nxml for element completion?
 
 (require 'cl-lib)

--- a/xquery-mode.el
+++ b/xquery-mode.el
@@ -314,7 +314,7 @@
     (1 font-lock-keyword-face))))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '(".xq[erxy]\\'" . xquery-mode))
+(add-to-list 'auto-mode-alist '("\\.\\(?:xquery\\|xq[elmry]?\\)\\'" . xquery-mode))
 
 (defun xquery-forward-sexp (&optional arg)
   "XQuery forward s-expresssion.


### PR DESCRIPTION
Remove .xqx, as that is for XQueryX, i.e. XQuery as XML.

Add .xquery, .xq, .xqm, .xql (as listed on the Wikipedia page for XQuery).